### PR TITLE
Fix compatibility with newer versions of gonzales-pe

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ var flatten = module.exports = function (data, includePath) {
     }
   }
 
-  return ast.toCSS('scss');
+  return ast.toString('scss');
 };
 
 var resolveScssPath = flatten.resolvePath = function (sassPath, includePaths) {
@@ -51,7 +51,7 @@ var resolveScssPath = flatten.resolvePath = function (sassPath, includePaths) {
 };
 
 function isImportStatement(node) {
-  return node.type == 'atrules' &&
+  return node.type == 'atrule' &&
     node.content[0].type == 'atkeyword' &&
     node.content[0].content[0].type == 'ident' &&
     node.content[0].content[0].content == 'import';


### PR DESCRIPTION
Since version 3.0.0-26 of gonzales-pe, they’ve made a few changes that
break sass-flatten:

* The returning `parseTree` object’s `toCSS` method has been renamed
`toString`
* the `atrules` node type is now named `atrule`

The changes in this PR fix sass-flatten so it works with the latest
versions of gonzales-pe (3.4.7 and 4.0.3 respectively)

The tests all pass on my local.